### PR TITLE
Fix pe-parser API issue

### DIFF
--- a/disassembly/pecodesource.cpp
+++ b/disassembly/pecodesource.cpp
@@ -59,8 +59,10 @@ PECodeSource::PECodeSource(const std::string& filename) : is_amd64_(false) {
   }
 
   peparse::iterSec section_callback = [](void* N,
-    peparse::VA section_base, std::string& section_name,
-    peparse::image_section_header s, peparse::bounded_buffer* data) -> int {
+    const peparse::VA &section_base,
+    const std::string &section_name,
+    const peparse::image_section_header &s,
+    const peparse::bounded_buffer* data) -> int {
     PECodeSource* pe_code_source = static_cast<PECodeSource*>(N);
 
     PECodeRegion* new_region =  new PECodeRegion(


### PR DESCRIPTION
This commit fixes build failure because of `pe-parser` API change.
I ran the default testsuite, which passed.
Some tests from the _slow_ testsuite fail.